### PR TITLE
Adding a tiny descriptor for better understanding and user experience

### DIFF
--- a/benchmarks.html
+++ b/benchmarks.html
@@ -240,6 +240,7 @@
             </li>
           </ul>
 
+          <div class="text-center" id="compare-text"><strong>Larger is better</strong></div>
           <br />
 
           <div class="tab-content text-left" data-aos="fade-in">
@@ -1681,6 +1682,15 @@
             }
           }
         }
+      });
+      document.querySelectorAll('.nav-link').forEach(tab => {
+        tab.addEventListener('click', () => {
+          if (tab.textContent == "Runtimes") {
+            document.getElementById("compare-text").innerHTML = "<strong>Smaller is better</strong>";
+          } else if (tab.textContent == "Speedups") {
+            document.getElementById("compare-text").innerHTML = "<strong>Larger is better</strong>";
+          }
+        });
       });
     </script>
   </body>


### PR DESCRIPTION
I changed a small part of the benchmarks page. Under the Speedups/Runtimes selector, I added some text to describe what the user should look for. Here is before/after:
![before](https://user-images.githubusercontent.com/44180430/227857123-b81d591c-b108-4a56-9e13-f7d0d9e367fb.png)
![after](https://user-images.githubusercontent.com/44180430/227857201-ecd6387e-d6c0-4930-870d-6e91a86c8452.png)
![before](https://user-images.githubusercontent.com/44180430/227857266-2110a774-b49c-452d-ac8b-2ba96797c40d.png)
![after](https://user-images.githubusercontent.com/44180430/227857315-b7d4eef6-f8af-4662-841f-bccf0c6b9aeb.png)